### PR TITLE
Use plotly.js for rendering chart

### DIFF
--- a/app/api/bdash-query/create.ts
+++ b/app/api/bdash-query/create.ts
@@ -37,24 +37,27 @@ const postBdashQuery = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
     query_sql: "",
     data_source_info: "",
     chart_svg: null,
+    chart_config: null,
     result: "",
   }
 
   Object.entries(body.files).forEach(([key, value]) => {
-    const extension = key.split(".").slice(-1)[0]
-    switch (extension) {
-      case "sql":
+    switch (key) {
+      case "query.sql":
         data.query_sql = value.content
         break
-      case "tsv":
+      case "result.tsv":
         const queryResult = convertTsvToQueryResult(value.content)
         data.result = queryResult ? JSON.stringify(queryResult) : null
         break
-      case "json":
+      case "data_source.json":
         data.data_source_info = normalizeDataSourceInfo(value.content)
         break
-      case "svg":
+      case "chart.svg":
         data.chart_svg = value.content
+        break
+      case "chart.json":
+        data.chart_config = value.content
         break
       default:
         console.error(`Unexpected file: ${key}`)

--- a/app/core/components/QueryResultChart.tsx
+++ b/app/core/components/QueryResultChart.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useRef } from "react"
+import Chart from "../lib/Chart"
+import { QueryResult } from "../lib/QueryResult"
+import { ContentBox } from "./ContentBox"
+
+type Props = {
+  queryResult: QueryResult
+  chartConfig: ChartType
+}
+
+const QueryResultChart: React.FC<Props> = ({ queryResult, chartConfig }) => {
+  const chartRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    drawChart(queryResult, chartConfig, chartRef)
+  }, [chartConfig, queryResult])
+  return (
+    <ContentBox>
+      <div ref={chartRef} />
+    </ContentBox>
+  )
+}
+
+export type ChartType = {
+  readonly id: number
+  readonly queryId: number
+  readonly type: "line" | "scatter" | "bar" | "area" | "pie"
+  readonly xColumn: string
+  readonly yColumns: Array<string>
+  readonly groupColumns: Array<string>
+  readonly stacking: 0 | string
+  readonly updatedAt: string
+  readonly createdAt: string
+}
+
+const drawChart = async (
+  queryResult: QueryResult,
+  chartConfig: ChartType,
+  targetElement: React.RefObject<HTMLDivElement>
+): Promise<void> => {
+  if (targetElement.current === null) return
+
+  const params = {
+    type: chartConfig.type,
+    x: chartConfig.xColumn,
+    y: chartConfig.yColumns,
+    stacking: chartConfig.stacking,
+    groupBy: chartConfig.groupColumns,
+    rows: queryResult.rows.map((row) =>
+      row.map((value) => (typeof value === "string" ? value : Number(value)))
+    ),
+    fields: queryResult.columns,
+  }
+
+  await new Chart(params).drawTo(targetElement.current)
+}
+
+export default QueryResultChart

--- a/app/core/components/QueryResultSvgChart.tsx
+++ b/app/core/components/QueryResultSvgChart.tsx
@@ -6,7 +6,7 @@ type Props = {
   chartSvg: string
 }
 
-export const Chart: React.FC<Props> = ({ chartSvg }) => {
+export const QueryResultSvgChart: React.FC<Props> = ({ chartSvg }) => {
   return (
     <ContentBox>
       <div className={styles.box} dangerouslySetInnerHTML={{ __html: chartSvg }} />

--- a/app/core/lib/Chart.ts
+++ b/app/core/lib/Chart.ts
@@ -1,0 +1,186 @@
+// Copied from https://github.com/bdash-app/bdash/blob/9846d67900db6782719c31923e73d7c197845429/src/lib/Chart.ts
+import Plotly, { PlotlyHTMLElement } from "plotly.js-basic-dist-min"
+import _ from "lodash"
+
+type Params = {
+  readonly type: "line" | "scatter" | "bar" | "area" | "pie"
+  readonly stacking: 0 | string
+  readonly groupBy: string[]
+  readonly rows: (string | number)[][]
+  readonly fields: string[]
+  readonly x: string
+  readonly y: string[]
+}
+
+export default class Chart {
+  private readonly params: Params
+
+  constructor(params: Params) {
+    this.params = params
+  }
+
+  drawTo(dom: HTMLElement): Promise<PlotlyHTMLElement> {
+    return Plotly.newPlot(dom, this.getData(), this.getLayout(), {
+      displayModeBar: false,
+      responsive: true,
+    })
+  }
+
+  async toSVG({ width }: { width: number }): Promise<string | null> {
+    const data = this.getData()
+    const layout = this.getLayout()
+    const div = document.createElement("div")
+
+    if (data.length === 0) {
+      return Promise.resolve(null)
+    }
+
+    const gd = await Plotly.plot(div, data, layout)
+    // aspect ratio (450:700) is default of plotly.js
+    // https://plot.ly/javascript/reference/#layout-width
+    // https://plot.ly/javascript/reference/#layout-height
+    const height = Math.floor((width * 450) / 700)
+    return Plotly.toImage(gd, { format: "svg", width, height }).then((svg) => {
+      const dataURI = decodeURIComponent(svg)
+      return dataURI.substr(dataURI.indexOf(",") + 1).replace(/"Open Sans"/g, "'Open Sans'")
+    })
+  }
+
+  getData(): Partial<Plotly.PlotData>[] {
+    return this[this.params.type]()
+  }
+
+  getLayout(): Partial<Plotly.Layout> {
+    const layout: Partial<Plotly.Layout> = {
+      showlegend: true,
+      margin: { l: 50, r: 50, t: 10, b: 10, pad: 4 },
+      hoverlabel: { namelength: -1 },
+      xaxis: { automargin: true },
+      yaxis: { automargin: true },
+    }
+
+    if (this.params.stacking === "enable") {
+      layout.barmode = "stack"
+    }
+    if (this.params.stacking === "percent") {
+      layout.barmode = "stack"
+      layout.barnorm = "percent"
+    }
+
+    return layout
+  }
+
+  // TODO: Performance tuning
+  generateChartData(): { x: (string | number)[]; y: (string | number)[]; name: string }[] {
+    if (!this.params.y) return []
+
+    if (
+      this.params.groupBy.length === 0 ||
+      _.difference(this.params.groupBy, this.params.fields).length > 0
+    ) {
+      return this.params.y.map((y) => {
+        return {
+          x: this.dataByField(this.params.x),
+          y: this.dataByField(y),
+          name: y,
+        }
+      })
+    }
+
+    // NOTE: Can delete sort?
+    const groupValues = this.params.groupBy.map((field) => _.uniq(this.dataByField(field)).sort())
+    const indices = this.params.groupBy.map((field) => this.rowIndexByFieldName(field))
+    const x = _.groupBy(this.params.rows, (row) => indices.map((idx) => row[idx]))
+
+    // The cartesian product of group values
+    const groupPairs = groupValues.reduce(
+      (a: any[][], b: any[]) => _.flatMap(a, (x) => b.map((y) => x.concat([y]))),
+      [[]]
+    )
+
+    return _.flatMap(this.params.y, (y) => {
+      const yIdx = this.rowIndexByFieldName(y)
+      return groupPairs.map((g) => {
+        const key = g.join(",")
+        return {
+          name: `${y} (${key})`,
+          x: this.valuesByField(
+            Object.prototype.hasOwnProperty.call(x, key) ? x[key] : [],
+            this.params.x
+          ),
+          y: this.params.rows
+            .filter((row) =>
+              // For all group by indices, the values in row and g match.
+              indices.reduce((a: boolean, b: number, i) => a && row[b] === g[i], true)
+            )
+            .map((row) => row[yIdx]),
+        }
+      })
+    })
+  }
+
+  rowIndexByFieldName(field: string): number {
+    return this.params.fields.findIndex((f) => f === field)
+  }
+
+  valuesByField(rows: (string | number)[][], field: string): (string | number)[] {
+    const idx = this.rowIndexByFieldName(field)
+    return rows.map((row) => row[idx])
+  }
+
+  dataByField(field: string): (string | number)[] {
+    return this.valuesByField(this.params.rows, field)
+  }
+
+  line(): Partial<Plotly.PlotData>[] {
+    return this.generateChartData().map((data) => ({
+      type: "scatter",
+      x: data.x,
+      y: data.y,
+      name: data.name,
+      mode: "lines",
+    }))
+  }
+
+  scatter(): Partial<Plotly.PlotData>[] {
+    return this.generateChartData().map((data) => ({
+      type: "scatter",
+      x: data.x,
+      y: data.y,
+      name: data.name,
+      mode: "markers",
+      marker: { size: 10 },
+    }))
+  }
+
+  bar(): Partial<Plotly.PlotData>[] {
+    return this.generateChartData().map((data) => ({
+      type: "bar",
+      x: data.x,
+      y: data.y,
+      name: data.name,
+    }))
+  }
+
+  area(): Partial<Plotly.PlotData>[] {
+    return this.generateChartData().map((data) => ({
+      type: "scatter",
+      x: data.x,
+      y: data.y,
+      name: data.name,
+      mode: "lines",
+      fill: "tozeroy",
+    }))
+  }
+
+  pie(): Partial<Plotly.PlotData>[] {
+    return [
+      {
+        type: "pie",
+        direction: "clockwise",
+        labels: this.dataByField(this.params.x),
+        values: this.dataByField(this.params.y[0]),
+      },
+    ]
+  }
+}

--- a/db/migrations/20220114143053_add_chart_config_column_to_bdash_query/migration.sql
+++ b/db/migrations/20220114143053_add_chart_config_column_to_bdash_query/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `BdashQuery` ADD COLUMN     `chart_config` VARCHAR(191);

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -80,6 +80,7 @@ model BdashQuery {
   query_sql        String     @db.Text
   data_source_info String?    @db.Text
   chart_svg        String?    @db.MediumText
+  chart_config     String?
   result           String?    @db.MediumText
   Favorite         Favorite[]
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "framer-motion": "3.2.0",
     "papaparse": "5.3.0",
     "passport-google-oauth20": "2.0.0",
+    "plotly.js-basic-dist-min": "2.8.3",
     "prisma": "~2.17",
     "react": "0.0.0-experimental-3310209d0",
     "react-dom": "0.0.0-experimental-3310209d0",
@@ -54,6 +55,7 @@
   },
   "devDependencies": {
     "@types/papaparse": "5.2.5",
+    "@types/plotly.js": "1.54.20",
     "@types/preview-email": "2.0.0",
     "@types/react": "17.0.3",
     "@types/react-syntax-highlighter": "13.5.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "tsBuildInfoFile": ".tsbuildinfo"
+    "tsBuildInfoFile": ".tsbuildinfo",
+    "paths": { "plotly.js-basic-dist-min": ["node_modules/@types/plotly.js"] }
   },
   "exclude": ["node_modules", "**/*.e2e.ts", "cypress"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2131,6 +2131,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/d3@^3":
+  version "3.5.46"
+  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-3.5.46.tgz#8b890138ea035b703ef4cdd2de0d86f8619c1c69"
+  integrity sha512-jNHfiGd41+JUV43LTMzQNidyp4Hn0XfhoSmy8baE0d/N5pGYpD+yX03JacY/MH+smFxYOQGXlz4HxkRZOuRNOQ==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -2260,6 +2265,13 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/plotly.js@1.54.20":
+  version "1.54.20"
+  resolved "https://registry.yarnpkg.com/@types/plotly.js/-/plotly.js-1.54.20.tgz#88fd8500f4860eb7590cb38366fa098618cc68df"
+  integrity sha512-vqiqq5chr72QoApD+6Hu52iuBvT5/po/sdVF74IBnacQV6J1MjH9OeFZ3GFDwKLF24xT++FMkEGAWcgVMwg2YQ==
+  dependencies:
+    "@types/d3" "^3"
 
 "@types/prettier@^2.0.0":
   version "2.2.3"
@@ -8821,6 +8833,11 @@ please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
+
+plotly.js-basic-dist-min@2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/plotly.js-basic-dist-min/-/plotly.js-basic-dist-min-2.8.3.tgz#538baff1455f05c7e313f22b6b61b44919372538"
+  integrity sha512-1K+2cNo8obMcf4aGr9GTu0KPjixoI8pfZNiJafrjiIwJ0EYjMalvt5OzF61M9usdRcbxCs6UDUkH4hMrBM8kZQ==
 
 pluralize@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
closes #14 

It now uses the same logic as in Bdash.app to draw a chart.

- I added new information about a chart to the parameter of the query creation request from Bdash.app (https://github.com/bdash-app/bdash/pull/206) and bdash-server stores it in the `chart_config` column of BdashQuery table.
- bdash-server draws a chart with plotly.js.
- bdash-server still draws charts as SVG for old data not having `chart_config`.


[![Image from Gyazo](https://i.gyazo.com/fb4fc9a5111108ddb4554b22963e64d5.gif)](https://gyazo.com/fb4fc9a5111108ddb4554b22963e64d5)