### PR TITLE
Do not clear existing values when updating a query

### DIFF
--- a/app/api/bdash-query/update.ts
+++ b/app/api/bdash-query/update.ts
@@ -38,14 +38,9 @@ const putBdashQuery = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
   }
 
   const data: Prisma.BdashQueryUpdateArgs["data"] = {
-    userId: user.id,
     title: body.description,
-    description: "",
-    query_sql: "",
-    data_source_info: "",
     chart_svg: null,
     chart_config: null,
-    result: "",
   }
 
   Object.entries(body.files).forEach(([key, value]) => {


### PR DESCRIPTION
closes https://github.com/bdash-app/bdash-server/issues/32

Avoid clearing a query's `description` and the other properties when it is updated.