### PR TITLE
Update Docker commands in README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 Run an app container with the image built by [Dockerfile](https://github.com/morishin/bdash-server/blob/main/Dockerfile) for production.
 
 ```sh
-docker-compose -f docker-compose-with-app-container.yml up --build
+docker compose -f docker-compose-with-app-container.yml up --build
 ```
 
 ## Tests

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bdash-server",
   "version": "1.0.0",
   "scripts": {
-    "dev": "docker-compose -f docker-compose-dev.yml up -d && blitz dev",
+    "dev": "docker compose -f docker-compose-dev.yml up -d && blitz dev",
     "build": "prisma generate --schema db/schema.prisma && blitz build",
     "start": "blitz start",
     "start:production": "blitz start --port $PORT",


### PR DESCRIPTION
The `docker-compose` command has been deprecated.
https://www.docker.com/blog/announcing-compose-v2-general-availability/

Also, when newly installing Docker on Ubuntu, this command was not included in the package.
Docker installation on Ubuntu follows this URL
https://docs.docker.com/engine/install/ubuntu/#installation-methods
