### PR TITLE
Paginate Bdash queries in /[userName]

### DIFF
--- a/app/core/components/UserPageContainer.tsx
+++ b/app/core/components/UserPageContainer.tsx
@@ -1,15 +1,34 @@
-import { Heading } from "@chakra-ui/react"
-import { Head } from "blitz"
-import { BdashQuery, User } from "db"
+import { Heading, HStack, Button } from "@chakra-ui/react"
+import { Head, usePaginatedQuery, useRouter } from "blitz"
+import { User } from "db"
 import React from "react"
 import { BdashQueryList } from "./BdashQueryList"
 import { ContentBox } from "./ContentBox"
+import getBdashQueries from "app/bdash-queries/queries/getBdashQueries"
+
+const ITEMS_PER_PAGE = 25;
 
 type Props = {
-  user: User & { BdashQuery: BdashQuery[] }
+  user: User
 }
 
 export const UserPageContainer: React.FC<Props> = ({ user }) => {
+  const router = useRouter();
+  const page = Number(router.query.page) || 0;
+  const [{ bdashQueries, hasMore }] = usePaginatedQuery(getBdashQueries, {
+    orderBy: { createdAt: "desc" },
+    skip: ITEMS_PER_PAGE * page,
+    take: ITEMS_PER_PAGE,
+    where: {
+      userId: user.id,
+    },
+  });
+
+  const goToPreviousPage = () => router.push({ query: { userName: user.name, page: page - 1 } });
+  const goToNextPage = () => router.push({ query: { userName: user.name, page: page + 1 } });
+
+  const isPagerHidden = page === 0 && !hasMore;
+
   return (
     <>
       <Head>
@@ -20,8 +39,18 @@ export const UserPageContainer: React.FC<Props> = ({ user }) => {
         <Heading as="h2" size="lg" marginBottom={4}>
           {`${user.name}'s queries`}
         </Heading>
-        <BdashQueryList queries={user.BdashQuery.map((query) => Object.assign(query, { user }))} />
+        <BdashQueryList queries={bdashQueries.map((query) => Object.assign(query, { user }))} />
+        {!isPagerHidden && (
+          <HStack marginTop={5} spacing={5}>
+            <Button colorScheme="teal" disabled={page === 0} onClick={goToPreviousPage}>
+              Previous
+            </Button>
+            <Button colorScheme="teal" disabled={!hasMore} onClick={goToNextPage}>
+              Next
+            </Button>
+          </HStack>
+        )}
       </ContentBox>
     </>
-  )
+  );
 }

--- a/app/users/queries/getUserByName.ts
+++ b/app/users/queries/getUserByName.ts
@@ -11,7 +11,6 @@ export default resolver.pipe(resolver.zod(GetUser), resolver.authorize(), async 
   // TODO: in multi-tenant app, you must add validation to ensure correct tenant
   const user = await db.user.findUnique({
     where: { name },
-    include: { BdashQuery: { orderBy: { createdAt: "desc" } } },
   })
 
   if (!user) throw new NotFoundError()


### PR DESCRIPTION
This PR adds pagination to the `/[userName]` page.

Currently, the `/[userName]` page tries to load all queries shared by the user. This can be a problem when the user shares many queries.
So I added a pagination feature just like as the index page.