### PR TITLE
Use MySQL 8.0 for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:18-buster as base
+FROM node:18-buster as base
 WORKDIR /app
 COPY package.json yarn.lock .npmrc ./
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,9 +1,6 @@
-version: "3.7"
-
 services:
   db:
-    platform: linux/x86_64
-    image: mysql:5.7
+    image: mysql:8.0
     volumes:
       - mysql-data:/var/lib/mysql
     environment:

--- a/docker-compose-with-app-container.yml
+++ b/docker-compose-with-app-container.yml
@@ -16,8 +16,7 @@ services:
       - db
     command: sh -c "yarn run db:migrate:production && yarn run start:production"
   db:
-    platform: linux/x86_64
-    image: mysql:5.7
+    image: mysql:8.0
     volumes:
       - mysql-data:/var/lib/mysql
     environment:


### PR DESCRIPTION
MySQL 5.7 の arm64 イメージが Docker Hub に無いため。