### PR TITLE
Multi keywords search

### DIFF
--- a/app/api/bdash-query/search.ts
+++ b/app/api/bdash-query/search.ts
@@ -14,9 +14,8 @@ const searchBdashQuery = async (req: BlitzApiRequest, res: BlitzApiResponse) => 
   }
 
   const sendResponse = (data: SearchBdashQueryResponse) => {
-    res.setHeader("Content-Type", "application/json")
     res.status(200)
-    res.send(JSON.stringify(data))
+    res.json(data)
   }
 
   const searchResults = await searchBdashQueries(keyword, {

--- a/app/api/bdash-query/search.ts
+++ b/app/api/bdash-query/search.ts
@@ -1,14 +1,8 @@
 import { BlitzApiRequest, BlitzApiResponse } from "blitz"
-import db, { User } from "db"
+import db, { BdashQuery, User } from "db"
 import { searchBdashQueries } from "app/core/lib/searchBdashQueries"
 
-type SearchBdashQueryResult = {
-  id: number
-  id_hash: string
-  title: string
-  createdAt: Date
-  userId: number
-}
+type SearchBdashQueryResult = Pick<BdashQuery, "id" | "id_hash" | "title" | "createdAt" | "userId">
 
 export type SearchBdashQueryResponse = (SearchBdashQueryResult & { user?: User })[]
 
@@ -25,7 +19,7 @@ const searchBdashQuery = async (req: BlitzApiRequest, res: BlitzApiResponse) => 
     res.send(JSON.stringify(data))
   }
 
-  const searchResults = await searchBdashQueries<SearchBdashQueryResult>(keyword, {
+  const searchResults = await searchBdashQueries(keyword, {
     id: true,
     id_hash: true,
     title: true,

--- a/app/api/mcp.ts
+++ b/app/api/mcp.ts
@@ -67,7 +67,7 @@ mcpServer.tool(
     try {
       const limit = 10
 
-      const searchResults = await searchBdashQueries<BdashQueryRow>(
+      const searchResults = await searchBdashQueries(
         keyword,
         {
           id: true,

--- a/app/api/mcp.ts
+++ b/app/api/mcp.ts
@@ -3,6 +3,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { BlitzApiHandler } from "blitz"
 import db, { BdashQuery } from "db"
 import { z } from "zod"
+import { searchBdashQueries } from "app/core/lib/searchBdashQueries"
 
 type BdashQueryRow = Pick<
   BdashQuery,
@@ -65,27 +66,19 @@ mcpServer.tool(
 
     try {
       const limit = 10
-      const likeArg = `%${keyword}%`
 
-      const searchResults = await db.$queryRaw<BdashQueryRow[]>`
-        select
-            id,
-            title,
-            description,
-            query_sql,
-            updatedAt,
-            data_source_info
-        from
-            BdashQuery
-        where
-            title like ${likeArg}
-            or description like ${likeArg}
-            or query_sql like ${likeArg}
-        order by
-            updatedAt desc
+      const searchResults = await searchBdashQueries<BdashQueryRow>(
+        keyword,
+        {
+          id: true,
+          title: true,
+          description: true,
+          query_sql: true,
+          updatedAt: true,
+          data_source_info: true,
+        },
         limit
-            ${limit}
-        ;`
+      )
 
       return {
         content: [
@@ -152,6 +145,5 @@ const handler: BlitzApiHandler = async (req, res) => {
     }
   }
 }
-
 
 export default handler

--- a/app/core/lib/searchBdashQueries.ts
+++ b/app/core/lib/searchBdashQueries.ts
@@ -1,0 +1,37 @@
+import db from "db"
+
+export const searchBdashQueries = async <T>(
+  keyword: string,
+  selectFields: Record<string, boolean>,
+  limit?: number
+): Promise<T[]> => {
+  const keywords = keyword
+    .trim()
+    .split(/\s+/)
+    .filter((k) => k.length > 0)
+
+  if (keywords.length === 0) {
+    return []
+  }
+
+  const andConditions = keywords.map((kw) => ({
+    OR: [
+      { title: { contains: kw } },
+      { description: { contains: kw } },
+      { query_sql: { contains: kw } },
+    ],
+  }))
+
+  const searchResults = await db.bdashQuery.findMany({
+    where: {
+      AND: andConditions,
+    },
+    select: selectFields,
+    orderBy: {
+      updatedAt: "desc",
+    },
+    ...(limit && { take: limit }),
+  })
+
+  return searchResults as T[]
+}

--- a/app/core/lib/searchBdashQueries.ts
+++ b/app/core/lib/searchBdashQueries.ts
@@ -1,10 +1,10 @@
-import db from "db"
+import db, { Prisma } from "db"
 
-export const searchBdashQueries = async <T>(
+export const searchBdashQueries = async <SelectFields extends Prisma.BdashQuerySelect>(
   keyword: string,
-  selectFields: Record<string, boolean>,
+  selectFields: SelectFields,
   limit?: number
-): Promise<T[]> => {
+): Promise<Prisma.BdashQueryGetPayload<{ select: SelectFields }>[]> => {
   const keywords = keyword
     .trim()
     .split(/\s+/)
@@ -33,5 +33,5 @@ export const searchBdashQueries = async <T>(
     ...(limit && { take: limit }),
   })
 
-  return searchResults as T[]
+  return searchResults
 }


### PR DESCRIPTION
Improved search logic so that items containing both “keywordA” and “keywordB” are returned when searching with "keywordA keywordB."

```ts
const andConditions = keywords.map((kw) => ({
  OR: [
    { title: { contains: kw } },
    { description: { contains: kw } },
    { query_sql: { contains: kw } },
  ],
}))

const searchResults = await db.bdashQuery.findMany({
  where: {
    AND: andConditions,
  },
  select: selectFields,
  orderBy: {
    updatedAt: "desc",
  },
  ...(limit && { take: limit }),
})
```