### PR TITLE
Add query URLs to MCP search results

### DIFF
--- a/app/api/mcp.ts
+++ b/app/api/mcp.ts
@@ -7,7 +7,7 @@ import { searchBdashQueries } from "app/core/lib/searchBdashQueries"
 
 type BdashQueryRow = Pick<
   BdashQuery,
-  "id" | "title" | "description" | "query_sql" | "updatedAt" | "data_source_info"
+  "id" | "id_hash" | "title" | "description" | "query_sql" | "updatedAt" | "data_source_info"
 >
 
 interface DataSourceInfo {
@@ -21,8 +21,10 @@ const formatSearchResult = (query: BdashQueryRow, index: number): string => {
   const dataSourceInfo = query.data_source_info
     ? (JSON.parse(query.data_source_info) as DataSourceInfo)
     : null
+  const queryUrl = `${process.env.WEB_HOST}/query/${query.id_hash}`
   return `${index + 1}. **${query.title}**
 
+URL: ${queryUrl}
 Data Source:
     - Type: ${dataSourceInfo?.type ?? "Unknown"}
     - Host: ${dataSourceInfo?.host ?? "Unknown"}
@@ -71,6 +73,7 @@ mcpServer.tool(
         keyword,
         {
           id: true,
+          id_hash: true,
           title: true,
           description: true,
           query_sql: true,


### PR DESCRIPTION
## Summary

Added query URLs to MCP API search results, enabling direct navigation from MCP clients like Claude Code to query pages on the web interface.

## Changes

### MCP API Enhancement
- Add query URL generation in `formatSearchResult` function
- Include `id_hash` field in `BdashQueryRow` type definition
- Use `WEB_HOST` environment variable to construct query page URLs
- Display clickable URLs in search response format

## Response Format

Search results now include URLs in this format:

```
1. **Query Title**

URL: https://your-domain.com/query/abc123hash
Data Source:
    - Type: MySQL
    - Host: localhost
    - Port: 3306
    - Database: mydb
Description: Sample query description
Updated: 2025-07-31T12:34:56.789Z
SQL:

SELECT * FROM users WHERE active = 1

```

## Benefits

- Direct navigation from MCP clients to query details
- Improved user experience for query discovery
- Quick access to query editing and detailed view

## Testing

- TypeScript compilation passes
- URL generation works correctly with WEB_HOST environment variable

🤖 Generated with [Claude Code](https://claude.ai/code)